### PR TITLE
BUGFIX: Icons not shown in KDE

### DIFF
--- a/usr/lib/prime-indicator/prime-indicator
+++ b/usr/lib/prime-indicator/prime-indicator
@@ -139,7 +139,7 @@ class Indicator:
                                                           AppIndicator3.IndicatorCategory.APPLICATION_STATUS,
                                                           self.icon_path)
         self.icon.set_status(AppIndicator3.IndicatorStatus.ACTIVE)
-        self.icon.set_icon(self.icon_name)
+        self.icon.set_icon(os.path.abspath(self.icon_path + "/" + self.icon_name))
         self.icon.set_title(self.icon_tooltip_text)
         self.icon.set_menu(self.menu)
 


### PR DESCRIPTION
Seems that it fixes issue https://github.com/andrebrait/prime-indicator/issues/7

Tested in Plasma 5.8.2
Not sure if it works in other Desktop Environments (I guess it should) :\
